### PR TITLE
Add state snapshots during trace

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 
 # Example recipe that takes a required input
 trace trace_name:
-    FILTER_TRACE={{trace_name}} cargo test --package solstice --bin solstice -- tracer::tests::test_debugger_traces --exact --show-output --nocapture
+    FILTER_TRACE={{trace_name}} cargo test --lib -- tracer::tests::test_debugger_traces --exact --show-output --nocapture
 
 fuzz-state:
-    FUZZ=1 cargo test --package solstice --bin solstice -- state::fuzz --show-output
+    FUZZ=1 cargo test --lib -- state::fuzz --show-output

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -359,6 +359,12 @@ impl Debugger {
         self.next()
     }
 
+    #[cfg(test)]
+    pub fn last(&mut self) {
+        // go to the last step in the trace
+        self.indx = self.trace.steps.len() - 1;
+    }
+
     pub fn scope(&self) -> Vec<Variable> {
         self.trace.scope(self.indx)
     }

--- a/src/testcases/test/example.t.test_double_parent.trace
+++ b/src/testcases/test/example.t.test_double_parent.trace
@@ -4,3 +4,6 @@
   [STMT] 16:8 scope=[parent_value_2]
   [STMT] 42:8 scope=[value2, parent_value_2]
 [STMT] 38:8 scope=[value, example]
+---
+Variable: value = "0"
+Variable: example = "0x0000000000000000000000000000000000000000"

--- a/src/testcases/test/example.t.test_main.trace
+++ b/src/testcases/test/example.t.test_main.trace
@@ -9,3 +9,5 @@
   [STMT] 16:8 scope=[value, val]
 [STMT] 12:8 scope=[value, example]
 [STMT] 22:8 scope=[value]
+---
+Variable: value = "2"

--- a/src/testcases/test/example.t.test_multiple_calls.trace
+++ b/src/testcases/test/example.t.test_multiple_calls.trace
@@ -15,3 +15,5 @@
   [STMT] 16:8 scope=[value, val]
 [STMT] 27:12 scope=[value]
 [STMT] 26:28 scope=[value]
+---
+Variable: value = "6"

--- a/src/testcases/test/try_catch.t.test_try_catch.trace
+++ b/src/testcases/test/try_catch.t.test_try_catch.trace
@@ -29,3 +29,6 @@
     [STMT] 9:12 scope=[val]
   [STMT] 28:12 scope=[cc, result, value]
 [STMT] 17:8 scope=[cc, result]
+---
+Variable: cc = "0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f"
+Variable: result = "3"

--- a/src/testcases/test/types.t.test_types.trace
+++ b/src/testcases/test/types.t.test_types.trace
@@ -3,3 +3,8 @@
 [STMT] 20:8 scope=[arg_0, arg_1, arg_2, arg_3]
 [STMT] 21:8 scope=[arg_0, arg_1, arg_2, arg_3]
 [STMT] 22:8 scope=[arg_0, arg_1, arg_2, arg_3]
+---
+Variable: arg_0 = "A"
+Variable: arg_1 = "A"
+Variable: arg_2 = "100"
+Variable: arg_3 = "0"

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -1742,6 +1742,7 @@ const SKIP_TRACE_LIST: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::debugger::Debugger;
     use crate::state::testing::compile_contract;
     use std::fmt::{Display, Write};
     use std::path::PathBuf;
@@ -2068,18 +2069,39 @@ mod tests {
                 debug_trace_json,
             )?;
 
-            let formatted = debug_trace.to_debug_format(workspace_path, &trace_context);
+            let mut formatted = debug_trace.to_debug_format(workspace_path, &trace_context);
+
+            let expected = fs::read_to_string(trace_test_case.expected_path).unwrap();
+            if expected.contains("---") {
+                // Include the state snapshot in the formatted output
+                let mut debugger = Debugger::new(debug_trace);
+                debugger.last();
+
+                let vars_in_scope = debugger.scope();
+
+                // resolve each variable
+                let mut state_result = String::new();
+                // TODO: Handle memory state resolution. The 'test_with_struct_value' uses a struct in memory.
+                for var in vars_in_scope {
+                    if let Some(result) = debugger.get_variable(var.id).unwrap() {
+                        // TODO: Handle function parameters
+                        let value: String = serde_json::from_str(&result.variables[0].value)?;
+                        state_result += &format!("Variable: {} = {:?}\n", var.name, value);
+                    }
+                }
+
+                formatted += &format!("---\n{}", state_result);
+            }
+
             std::fs::write(
                 format!("{}/debug_trace.txt", log_output_dir),
                 formatted.clone(),
             )?;
 
-            let expected = fs::read_to_string(trace_test_case.expected_path).unwrap();
-
             println!("{}", formatted);
             println!("{}", expected);
 
-            assert_eq!(formatted, expected);
+            assert_eq!(formatted, expected, "incorrect trace");
         }
 
         Ok(())


### PR DESCRIPTION
The trace integration tests have been updated to include also the snapshot of the state at the end of the execution.

Closes #49 