### PR TITLE
Update solang: removes the use of the keyword 'persistent'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6667,7 +6667,7 @@ dependencies = [
 [[package]]
 name = "solang"
 version = "0.3.3"
-source = "git+http://github.com/ferranbt/solang?rev=6e27d6dbbbc75e672f2ea2d85a712990fca78105#6e27d6dbbbc75e672f2ea2d85a712990fca78105"
+source = "git+http://github.com/ferranbt/solang?rev=f89387824c34097bd12f02d6745350f937d4054a#f89387824c34097bd12f02d6745350f937d4054a"
 dependencies = [
  "anchor-syn",
  "base58",
@@ -6686,7 +6686,7 @@ dependencies = [
  "indexmap 2.9.0",
  "ink_env",
  "ink_metadata",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "normalize-path",
  "num-bigint",
  "num-integer",
@@ -6733,7 +6733,7 @@ dependencies = [
 [[package]]
 name = "solang-parser"
 version = "0.3.3"
-source = "git+http://github.com/ferranbt/solang?rev=6e27d6dbbbc75e672f2ea2d85a712990fca78105#6e27d6dbbbc75e672f2ea2d85a712990fca78105"
+source = "git+http://github.com/ferranbt/solang?rev=f89387824c34097bd12f02d6745350f937d4054a#f89387824c34097bd12f02d6745350f937d4054a"
 dependencies = [
  "itertools 0.12.1",
  "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ rustc-hash = "1.1"
 semver = "1"
 dap = "0.4.1-alpha1"
 clap = { version = "4.5.16", features = ["derive"] }
-solang-parser = { git = "http://github.com/ferranbt/solang", rev = "6e27d6dbbbc75e672f2ea2d85a712990fca78105" }
-solang = { git = "http://github.com/ferranbt/solang", rev = "6e27d6dbbbc75e672f2ea2d85a712990fca78105", default-features = false }
+solang-parser = { git = "http://github.com/ferranbt/solang", rev = "f89387824c34097bd12f02d6745350f937d4054a" }
+solang = { git = "http://github.com/ferranbt/solang", rev = "f89387824c34097bd12f02d6745350f937d4054a", default-features = false }
 forge-fmt = "0.2.0"
 anstream = "0.6.18"
 arbitrary = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Update to a new version of Solang parser which removes the use of the 'persistent' keyword which is available in Solana.