### PR TITLE
Update solang parser: Error selector + tload/tstore + track yul vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6667,7 +6667,7 @@ dependencies = [
 [[package]]
 name = "solang"
 version = "0.3.3"
-source = "git+http://github.com/ferranbt/solang?rev=f89387824c34097bd12f02d6745350f937d4054a#f89387824c34097bd12f02d6745350f937d4054a"
+source = "git+http://github.com/ferranbt/solang?rev=3635de23dbd7302b5d6618094d1802f9bbebf9fe#3635de23dbd7302b5d6618094d1802f9bbebf9fe"
 dependencies = [
  "anchor-syn",
  "base58",
@@ -6733,7 +6733,7 @@ dependencies = [
 [[package]]
 name = "solang-parser"
 version = "0.3.3"
-source = "git+http://github.com/ferranbt/solang?rev=f89387824c34097bd12f02d6745350f937d4054a#f89387824c34097bd12f02d6745350f937d4054a"
+source = "git+http://github.com/ferranbt/solang?rev=3635de23dbd7302b5d6618094d1802f9bbebf9fe#3635de23dbd7302b5d6618094d1802f9bbebf9fe"
 dependencies = [
  "itertools 0.12.1",
  "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ rustc-hash = "1.1"
 semver = "1"
 dap = "0.4.1-alpha1"
 clap = { version = "4.5.16", features = ["derive"] }
-solang-parser = { git = "http://github.com/ferranbt/solang", rev = "f89387824c34097bd12f02d6745350f937d4054a" }
-solang = { git = "http://github.com/ferranbt/solang", rev = "f89387824c34097bd12f02d6745350f937d4054a", default-features = false }
+solang-parser = { git = "http://github.com/ferranbt/solang", rev = "3635de23dbd7302b5d6618094d1802f9bbebf9fe" }
+solang = { git = "http://github.com/ferranbt/solang", rev = "3635de23dbd7302b5d6618094d1802f9bbebf9fe", default-features = false }
 forge-fmt = "0.2.0"
 anstream = "0.6.18"
 arbitrary = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Update solang to this commit https://github.com/ferranbt/solang/commit/3635de23dbd7302b5d6618094d1802f9bbebf9fe

It adds three changes:
- Enables the `selector` method for error types.
- Tracks variable usages in yul code.
- Parses `tload/tstore` yul opcodes.