### PR TITLE
Update solang parser: Fix import of internal structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6667,7 +6667,7 @@ dependencies = [
 [[package]]
 name = "solang"
 version = "0.3.3"
-source = "git+http://github.com/ferranbt/solang?rev=f89387824c34097bd12f02d6745350f937d4054a#f89387824c34097bd12f02d6745350f937d4054a"
+source = "git+http://github.com/ferranbt/solang?rev=99859e24e85f657b6e9b74aea02d354505b1069e#99859e24e85f657b6e9b74aea02d354505b1069e"
 dependencies = [
  "anchor-syn",
  "base58",
@@ -6733,7 +6733,7 @@ dependencies = [
 [[package]]
 name = "solang-parser"
 version = "0.3.3"
-source = "git+http://github.com/ferranbt/solang?rev=f89387824c34097bd12f02d6745350f937d4054a#f89387824c34097bd12f02d6745350f937d4054a"
+source = "git+http://github.com/ferranbt/solang?rev=99859e24e85f657b6e9b74aea02d354505b1069e#99859e24e85f657b6e9b74aea02d354505b1069e"
 dependencies = [
  "itertools 0.12.1",
  "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ rustc-hash = "1.1"
 semver = "1"
 dap = "0.4.1-alpha1"
 clap = { version = "4.5.16", features = ["derive"] }
-solang-parser = { git = "http://github.com/ferranbt/solang", rev = "f89387824c34097bd12f02d6745350f937d4054a" }
-solang = { git = "http://github.com/ferranbt/solang", rev = "f89387824c34097bd12f02d6745350f937d4054a", default-features = false }
+solang-parser = { git = "http://github.com/ferranbt/solang", rev = "99859e24e85f657b6e9b74aea02d354505b1069e" }
+solang = { git = "http://github.com/ferranbt/solang", rev = "99859e24e85f657b6e9b74aea02d354505b1069e", default-features = false }
 forge-fmt = "0.2.0"
 anstream = "0.6.18"
 arbitrary = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Update solang to commit https://github.com/ferranbt/solang/commit/99859e24e85f657b6e9b74aea02d354505b1069e which fixes the import of internal symbols from a contract. 