### PR TITLE
Fix function argument decode

### DIFF
--- a/src/debugger/testcases/test/example.t.sol
+++ b/src/debugger/testcases/test/example.t.sol
@@ -31,7 +31,9 @@ contract FooTest is Test {
     function test_contract_calls() external {
         Example example = new Example();
         example.set_parent_value(1);
-        example.set_parent_value_1(1);
+        example.set_parent_value_1(3);
+        example.set_parent_value_1(2222);
+        // value = 1;
     }
 
     function test_double_parent() external {

--- a/src/debugger/testcases/test/example.t.test_contract_calls.trace
+++ b/src/debugger/testcases/test/example.t.test_contract_calls.trace
@@ -14,5 +14,5 @@
   [EXIT] 7:65 scope=[parent_value_2, new_parent_value]
 [EXIT] 31:44 scope=[value]
 ---
-Variable: parent_value_2 = "0"
-Variable: new_parent_value = "149401154"
+Variable: parent_value_2 = "3"
+Variable: new_parent_value = "2222"

--- a/src/debugger/testcases/test/example.t.test_contract_calls.trace
+++ b/src/debugger/testcases/test/example.t.test_contract_calls.trace
@@ -12,7 +12,11 @@
   [FUNC] set_parent_value_1 (src/parent.sol:7)
   [STMT] 8:8 scope=[parent_value_2, new_parent_value]
   [EXIT] 7:65 scope=[parent_value_2, new_parent_value]
+[CALL] 35:8
+  [FUNC] set_parent_value_1 (src/parent.sol:7)
+  [STMT] 8:8 scope=[parent_value_2, new_parent_value]
+  [EXIT] 7:65 scope=[parent_value_2, new_parent_value]
 [EXIT] 31:44 scope=[value]
 ---
-Variable: parent_value_2 = "3"
+Variable: parent_value_2 = "1"
 Variable: new_parent_value = "2222"

--- a/src/debugger/testcases/test/example.t.test_double_parent.trace
+++ b/src/debugger/testcases/test/example.t.test_double_parent.trace
@@ -1,11 +1,11 @@
-[FUNC] test_double_parent (test/example.t.sol:37)
-[CREATE] 38:8
+[FUNC] test_double_parent (test/example.t.sol:39)
+[CREATE] 40:8
   [FUNC] constructor (src/example1.sol:41)
   [STMT] 16:8 scope=[parent_value_2]
   [STMT] 42:8 scope=[value2, parent_value_2]
   [EXIT] 37:0 scope=[]
-[STMT] 38:8 scope=[value, example]
-[EXIT] 37:43 scope=[value]
+[STMT] 40:8 scope=[value, example]
+[EXIT] 39:43 scope=[value]
 ---
 Variable: value = "0"
 Variable: example = "0x0000000000000000000000000000000000000000"

--- a/src/debugger/testcases/test/example.t.test_with_struct_value.trace
+++ b/src/debugger/testcases/test/example.t.test_with_struct_value.trace
@@ -1,8 +1,8 @@
-[FUNC] test_with_struct_value (test/example.t.sol:41)
-[STMT] 42:8 scope=[value, s]
-[STMT] 43:8 scope=[value, s]
+[FUNC] test_with_struct_value (test/example.t.sol:43)
 [STMT] 44:8 scope=[value, s]
-[EXIT] 41:47 scope=[value]
+[STMT] 45:8 scope=[value, s]
+[STMT] 46:8 scope=[value, s]
+[EXIT] 43:47 scope=[value]
 ---
 Variable: value = "3"
 Variable: s = {"value":"123"}

--- a/src/debugger/tracer.rs
+++ b/src/debugger/tracer.rs
@@ -1513,6 +1513,7 @@ impl Builder {
                                 vars,
                                 debug_unit_to_test.path.clone(),
                                 indx,
+                                debug_unit_to_test.contract_name.clone(),
                             ));
                         }
                     }
@@ -1530,6 +1531,10 @@ impl Builder {
             for chunk in chunks {
                 let first_entry = chunk
                     .first()
+                    .expect("There has to be at least one entry in the chunk");
+
+                let last_entry = chunk
+                    .last()
                     .expect("There has to be at least one entry in the chunk");
 
                 let elem = first_entry.2.clone();
@@ -1605,6 +1610,27 @@ impl Builder {
                                 return Err(TraceError::FoundFunctionEntryWithoutCall);
                             }
                             expecting_function = false;
+
+                            // Override the state snapshot to use the last entry for both stack and memory so that
+                            // we can have the parameters and their final state before the function starts.
+                            let memory = Bytes::from(
+                                last_entry.0.memory.clone().unwrap().as_bytes().to_vec(),
+                            );
+                            let stack: Vec<Bytes> = last_entry
+                                .0
+                                .stack
+                                .clone()
+                                .unwrap()
+                                .iter()
+                                .map(|b| Bytes::from(b.to_be_bytes_vec()))
+                                .collect();
+
+                            let state_snapshot = StateSnapshot {
+                                memory,
+                                stack,
+                                // storage we really do not care that much because it is not going to change due to a function definition
+                                storage: state_snapshot.storage.clone(),
+                            };
 
                             // add the parameters to the assignments table
                             let num_params = func.parameters.len();

--- a/src/debugger/tracer.rs
+++ b/src/debugger/tracer.rs
@@ -1513,7 +1513,6 @@ impl Builder {
                                 vars,
                                 debug_unit_to_test.path.clone(),
                                 indx,
-                                debug_unit_to_test.contract_name.clone(),
                             ));
                         }
                     }


### PR DESCRIPTION
This PR fixes a regression after #162. The function definition should take as a reference to calculate the parameters in the stack the size of the stack at the end of the source map "chunk" that defines such function definition. Otherwise, the stack is not populated to know the reference position of the parameters.

